### PR TITLE
fix(plugin): route plugin log.info to stderr instead of stdout

### DIFF
--- a/packages/dripline/src/plugin/api.ts
+++ b/packages/dripline/src/plugin/api.ts
@@ -79,7 +79,10 @@ export function createPluginAPI(pluginId: string): {
     },
     log: {
       info(msg: string) {
-        console.log(`[${name}] ${msg}`);
+        // stderr, not stdout: plugins can run inside hosts whose stdout is a
+        // machine protocol channel (e.g. an NDJSON RPC stream), and a stray
+        // "[<name>] ..." line corrupts it. warn/error already go to stderr.
+        process.stderr.write(`[${name}] ${msg}\n`);
       },
       warn(msg: string) {
         console.warn(`[${name}] ${msg}`);

--- a/packages/dripline/src/tests/plugin-api.test.ts
+++ b/packages/dripline/src/tests/plugin-api.test.ts
@@ -103,6 +103,27 @@ describe("createPluginAPI", () => {
     api.log.warn("test");
     api.log.error("test");
   });
+
+  it("log.info writes to stderr, never stdout", () => {
+    const { api } = createPluginAPI("t");
+    const origLog = console.log;
+    const origWrite = process.stderr.write;
+    const stdoutLines: string[] = [];
+    const stderrChunks: string[] = [];
+    console.log = (...args: any[]) => stdoutLines.push(args.map(String).join(" "));
+    process.stderr.write = ((chunk: any) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      api.log.info("hello");
+    } finally {
+      console.log = origLog;
+      process.stderr.write = origWrite;
+    }
+    assert.equal(stdoutLines.length, 0);
+    assert.deepEqual(stderrChunks, ["[t] hello\n"]);
+  });
 });
 
 describe("resolvePluginExport", () => {


### PR DESCRIPTION
## Problem

`createPluginAPI`'s `log.info` uses `console.log`, so every plugin info line lands on **stdout**. Plugins can run inside hosts whose stdout is a machine protocol channel — in our case the vex pi worker, whose stdout is an NDJSON RPC stream back to the parent process. Every `[salesforce-live] SF session acquired`-style line from a plugin's `log.info` corrupted the stream and produced a `SyntaxError: JSON Parse error: Unexpected identifier "salesforce"` in the host's platform log (diagnosed on a production box, dripline@0.9.16).

`warn` and `error` already go to stderr (via `console.warn`/`console.error`) — `info` was the only one polluting stdout.

## Fix

`log.info` now writes to `process.stderr` directly. Same `[<name>] <msg>` format, just the safe stream.

## Tests

- New regression test: `log.info` emits exactly `[<name>] <msg>\n` on stderr and nothing on stdout.
- `bun run --filter dripline test`: 463 pass / 5 fail — the 5 failures are `http.test.ts` hitting `httpbin.org`, which my environment blocks; they fail identically on a clean checkout of `main`. All plugin-api tests pass.
- `bun run --filter dripline build` (tsc) clean.

## Context

This replaces a vendored bun patch we were carrying in our own repo (shift-labs-ai/vex#541) — reviewer asked for the fix to land upstream instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3CHXfohw4smDxMS1LhUfF